### PR TITLE
feat(modernize): Replace Bluebird with native promises, update Buffer code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  extends: "eslint-config-lob"
+  "extends": "lob",
+  "parserOptions": {
+    "ecmaVersion": 2018
+  }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: "calipers-pdf"
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  ci:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    # Run the same tests suite for node 12, 14, 16
+    strategy:
+      matrix:
+        node-version: [12, 14, 16, 18]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install packages
+        run: |
+          sudo apt-get -y install \
+            libpoppler-cpp-dev \
+            libpoppler-private-dev \
+            g++
+
+      # Setup this version of Node
+      # Cache is saved and restored by actions/setup-node
+      - name: Use Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+
+      - name: Enforce test coverage
+        run: npm run enforce
+
+      - name: Run lint
+        run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "calipers-pdf"
+name: "calipers-png"
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - '0.10.32'
-  - '0.12.2'
-  - '4.1.2'
-script:
-  - npm test
-  - npm run enforce
-  - npm run lint

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,22 +1,22 @@
 'use strict';
 
-var fs      = require('fs');
-var Promise = require('bluebird');
-var pread   = Promise.promisify(fs.read, { multiArgs: true });
+const fs    = require('fs');
 var utils   = require('./utils');
+const util  = require('util')
+const pread = util.promisify(fs.read);
 
 exports.detect = function (buffer) {
   return utils.ascii(buffer, 1, 8) === 'PNG\r\n\x1a\n' && utils.ascii(buffer, 12, 16) === 'IHDR';
 };
 
-exports.measure = function (path, fd) {
-  return pread(fd, new Buffer(8), 0, 8, 16)
-  .spread(function (bytesRead, buffer) {
+exports.measure = async function (path, fd) {
+  return pread(fd, Buffer.alloc(8), 0, 8, 16)
+  .then(function (readObject) {
     return {
       type: 'png',
       pages: [{
-        width: buffer.readUInt32BE(0),
-        height: buffer.readUInt32BE(4)
+        width: readObject.buffer.readUInt32BE(0),
+        height: readObject.buffer.readUInt32BE(4)
       }]
     };
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const fs    = require('fs');
-var utils   = require('./utils');
-const util  = require('util')
+const utils   = require('./utils');
+const util  = require('util');
 const pread = util.promisify(fs.read);
 
 exports.detect = function (buffer) {
@@ -11,13 +11,13 @@ exports.detect = function (buffer) {
 
 exports.measure = async function (path, fd) {
   return pread(fd, Buffer.alloc(8), 0, 8, 16)
-  .then(function (readObject) {
-    return {
-      type: 'png',
-      pages: [{
-        width: readObject.buffer.readUInt32BE(0),
-        height: readObject.buffer.readUInt32BE(4)
-      }]
-    };
-  });
+    .then((readObject) => {
+      return {
+        type: 'png',
+        pages: [{
+          width: readObject.buffer.readUInt32BE(0),
+          height: readObject.buffer.readUInt32BE(4)
+        }]
+      };
+    });
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "NODE_ENV=test nyc mocha -- test --recursive --timeout 15000",
     "enforce": "nyc check-coverage --statement 100 --branch 100 --function 100 --lines 100",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "lint:fix": "eslint --fix ."
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "PNG plugin for calipers.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "NODE_ENV=test istanbul cover _mocha -- test --recursive --timeout 15000",
-    "enforce": "istanbul check-coverage --statement 100 --branch 100 --function 100 --lines 100",
+    "test": "NODE_ENV=test nyc mocha -- test --recursive --timeout 15000",
+    "enforce": "nyc check-coverage --statement 100 --branch 100 --function 100 --lines 100",
     "lint": "eslint ."
   },
   "repository": {
@@ -25,15 +25,13 @@
   "homepage": "https://github.com/calipersjs/calipers-png",
   "devDependencies": {
     "chai": "2.x.x",
-    "coveralls": "2.x.x",
-    "eslint": "1.x.x",
-    "eslint-config-lob": "1.x.x",
-    "istanbul": "0.x.x",
-    "mocha": "2.x.x",
+    "eslint": "7.11.0",
+    "eslint-config-lob": "5.2.0",
+    "nyc": "15.1.0",
+    "mocha": "10.0.0",
     "mocha-lcov-reporter": "0.x.x"
   },
   "dependencies": {
-    "bluebird": "3.x.x"
   },
   "peerDependencies": {
     "calipers": "2.x.x"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,7 +40,6 @@ describe('png', function () {
         var pngPath = path.resolve(fixtures, file);
         var fd = fs.openSync(pngPath, 'r');
         return png.measure(pngPath, fd)
-        .bind({})
         .then(function (result) {
           expect(result).to.eql(expectedOutput);
         })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,51 +1,53 @@
 'use strict';
 
-var fs     = require('fs');
-var path   = require('path');
-var expect = require('chai').expect;
-var png    = require('../lib/index');
+const fs     = require('fs');
+const path   = require('path');
+const expect = require('chai').expect;
+const png    = require('../lib/index');
 
-describe('png', function () {
+describe('png', () => {
 
-  describe('detect', function () {
-    it('should return true for a PNG', function () {
-      var pngPath = path.resolve(__dirname, 'fixtures/png/123x456.png');
-      var result = png.detect(fs.readFileSync(pngPath));
+  describe('detect', () => {
+
+    it('should return true for a PNG', () => {
+      const pngPath = path.resolve(__dirname, 'fixtures/png/123x456.png');
+      const result = png.detect(fs.readFileSync(pngPath));
       expect(result).to.eql(true);
     });
 
-    it('should return false for a non-PNG', function () {
-      var jpegPath = path.resolve(__dirname, 'fixtures/jpeg/123x456.jpg');
-      var result = png.detect(fs.readFileSync(jpegPath));
+    it('should return false for a non-PNG', () => {
+      const jpegPath = path.resolve(__dirname, 'fixtures/jpeg/123x456.jpg');
+      const result = png.detect(fs.readFileSync(jpegPath));
       expect(result).to.eql(false);
     });
+
   });
 
-  describe('measure', function () {
+  describe('measure', () => {
 
-    var fixtures = path.resolve(__dirname, 'fixtures/png');
-    var files = fs.readdirSync(fixtures);
+    const fixtures = path.resolve(__dirname, 'fixtures/png');
+    const files = fs.readdirSync(fixtures);
 
-    files.forEach(function (file) {
+    files.forEach((file) => {
 
-      var fileSplit = file.split(/x|\./);
-      var width = parseInt(fileSplit[0]);
-      var height = parseInt(fileSplit[1]);
-      var expectedOutput = {
+      const fileSplit = file.split(/x|\./);
+      const width = parseInt(fileSplit[0]);
+      const height = parseInt(fileSplit[1]);
+      const expectedOutput = {
         type: 'png',
-        pages: [{ width: width, height: height }]
+        pages: [{ width, height }]
       };
 
-      it('should return the correct dimensions for ' + file, function () {
-        var pngPath = path.resolve(fixtures, file);
-        var fd = fs.openSync(pngPath, 'r');
+      it(`should return the correct dimensions for ${  file}`, () => {
+        const pngPath = path.resolve(fixtures, file);
+        const fd = fs.openSync(pngPath, 'r');
         return png.measure(pngPath, fd)
-        .then(function (result) {
-          expect(result).to.eql(expectedOutput);
-        })
-        .finally(function () {
-          fs.closeSync(fd);
-        });
+          .then((result) => {
+            expect(result).to.eql(expectedOutput);
+          })
+          .finally(() => {
+            fs.closeSync(fd);
+          });
       });
 
     });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -8,7 +8,7 @@ describe('utils', function () {
   describe('ascii', function () {
     it('should return the correct string', function () {
       var string = 'Test String%!@#\n';
-      var buffer = new Buffer(string);
+      var buffer = Buffer.from(string);
       var result = utils.ascii(buffer, 0, string.length);
       return expect(result).to.eql(string);
     });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,17 +1,19 @@
 'use strict';
 
-var expect = require('chai').expect;
-var utils  = require('../lib/utils');
+const expect = require('chai').expect;
+const utils = require('../lib/utils');
 
-describe('utils', function () {
+describe('utils', () => {
 
-  describe('ascii', function () {
-    it('should return the correct string', function () {
-      var string = 'Test String%!@#\n';
-      var buffer = Buffer.from(string);
-      var result = utils.ascii(buffer, 0, string.length);
+  describe('ascii', () => {
+
+    it('should return the correct string', () => {
+      const string = 'Test String%!@#\n';
+      const buffer = Buffer.from(string);
+      const result = utils.ascii(buffer, 0, string.length);
       return expect(result).to.eql(string);
     });
+
   });
 
 });


### PR DESCRIPTION
- Updates to new Buffer standard(Buffer.alloc, Buffer.from)
- Migrates to Native promises over bluebird
    - No need for a spread operator anymore since the promisified version of fs.read returns an object(https://nodejs.org/api/fs.html#fsreadfd-buffer-offset-length-position-callback)
- Updates lint